### PR TITLE
Second (empty) class attribute removed.

### DIFF
--- a/resources/views/partials/nav-site.blade.php
+++ b/resources/views/partials/nav-site.blade.php
@@ -26,7 +26,7 @@
 								@endforeach
 							</ul>
 							<div class="dropdown__see-all">
-							<a class="dropdown__see-all-btn" href="{{ get_page_link($topLevelPage->ID) }}" class="">
+							<a class="dropdown__see-all-btn" href="{{ get_page_link($topLevelPage->ID) }}">
 								<span class="mr1">Se allt inom {{ $topLevelPage->post_title }}</span>
 								<svg class="icon-badge icon-badge--md">
 									<use xlink:href="#arrow-right"/>


### PR DESCRIPTION
Noticed that validating our site complained about empty second class attribute. Removed it in this commit. 