### PR TITLE
Removed placeholder text from main menu

### DIFF
--- a/resources/views/partials/nav-site.blade.php
+++ b/resources/views/partials/nav-site.blade.php
@@ -26,7 +26,7 @@
 								@foreach($topLevelPage->children as $childPage)
 								<li class="dropdown__item">
 									<a href="{{ get_page_link($childPage->ID) }}" class="dropdown__link">{{ $childPage->post_title }}</a>
-									<span class="dropdown__link-description">Information om ambulanssjukvården</span>
+									<span class="dropdown__link-description"></span>
 								</li>
 								@endforeach
 							</ul>


### PR DESCRIPTION
A quick fix - feel fre to remove span as well. Just wanted the placeholder text removed from the prod site :)