### PR TITLE
fix content bug where p-tag is not added

### DIFF
--- a/app/Traits/NavContent.php
+++ b/app/Traits/NavContent.php
@@ -8,25 +8,22 @@ trait NavContent
 {
     public function __construct()
     {
-        add_filter( 'the_content', array($this, 'addIdToHeadings'));
+        add_filter( 'the_content', function($content) {
+           return self::addIdToHeadings($content);
+        });
     }
 
     /**
      * Parses post content and adds slugified inner text of headings as ID on each heading
      * @return object
      */
-    public function addIdToHeadings() {
-        global $post;
-
-        if (!is_a($post, 'WP_Post')) {
+    private function addIdToHeadings( $content ) {
+        
+        if (strlen($content) <= 0) {
             return;
         }
 
-        if (strlen($post->post_content) <= 0) {
-            return;
-        }
-
-        $content = HtmlDomParser::str_get_html($post->post_content);
+        $content = HtmlDomParser::str_get_html($content);
         
         foreach ($content->find('h2, h3, h4') as $element) {
             $slug = sanitize_title($element->innertext);


### PR DESCRIPTION
Paragraphs was never added because `NavContent.php` parsed the content directly from `$post`, losing any previous filtering, in this case from `wpautop()`.

* [https://stackoverflow.com/questions/3488849/wordpress-custom-the-content-filter-is-removing-other-filters-ie-wpautop](https://stackoverflow.com/questions/3488849/wordpress-custom-the-content-filter-is-removing-other-filters-ie-wpautop)
* [https://developer.wordpress.org/reference/functions/wpautop/](https://developer.wordpress.org/reference/functions/wpautop/)